### PR TITLE
Add omniauth-rails_csrf_protection gem to fix omniauth vulnerability …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'mini_racer', platforms: :ruby
 gem 'devise'
 gem 'omniauth', '~> 1.9'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 gem 'bootstrap', '~> 4.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,9 @@ GEM
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     pg (1.2.3)
     popper_js (1.16.0)
@@ -297,6 +300,7 @@ DEPENDENCIES
   mini_racer
   omniauth (~> 1.9)
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/spec/requests/omniauth_request_spec.rb
+++ b/spec/requests/omniauth_request_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe 'CVE-2015-9284', type: :request do
+  describe 'GET /auth/:provider' do
+    it do
+      get '/users/auth/google_oauth2'
+      expect(response).not_to have_http_status(:redirect)
+    end
+  end
+
+  describe 'POST /users/auth/:provider without CSRF token' do
+    before do
+      @allow_forgery_protection = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+    end
+
+    it do
+      expect {
+        post '/users/auth/google_oauth2'
+      }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    after do
+      ActionController::Base.allow_forgery_protection = @allow_forgery_protection
+    end
+  end
+end


### PR DESCRIPTION

## Purpose
Add omniauth-rails_csrf_protection gem to fix omniauth vulnerability issues in rails, create omniauth request spec to test security patch

## Approach
Github identified this issue and directed me to download the specified gem and include the RSpec test

#### Open Questions and Pre-Merge TODOs
- We may need to UPDATE THIS TEST, once we remove the /users/ namespace for MVP (not necessary)

#### SEE GITHUB LINKS
* VULNERABILITY: https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
* RSPEC TESTING: https://github.com/omniauth/omniauth/pull/809#issuecomment-512689882
